### PR TITLE
Change output size of segmentation sample to match input size rather than segmentation size

### DIFF
--- a/Vitis-AI-Library/samples/segmentation/process_result.hpp
+++ b/Vitis-AI-Library/samples/segmentation/process_result.hpp
@@ -13,21 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#pragma once
-#include <opencv2/core.hpp>
-#include <opencv2/highgui.hpp>
-#include <opencv2/imgproc.hpp>
+static void overLay(cv::Mat &src1, const cv::Mat &src2) {
+  const int imsize = src1.cols * src2.rows * 3;
+  for (int i = 0; i < imsize; ++i) {
+    src1.data[i] = src1.data[i] / 2 + src2.data[i] / 2;
+  }
+}
+
 static cv::Mat process_result(cv::Mat &m1,
                               const xilinx::ai::SegmentationResult &result,
                               bool is_jpeg) {
   cv::Mat image;
-  cv::resize(m1, image, result.segmentation.size());
-  for (auto row_ind = 0; row_ind < image.size().height; ++row_ind) {
-    for (auto col_ind = 0; col_ind < image.size().width; ++col_ind) {
-      image.at<cv::Vec3b>(row_ind, col_ind) =
-          image.at<cv::Vec3b>(row_ind, col_ind) * 0.5 +
-          result.segmentation.at<cv::Vec3b>(row_ind, col_ind) * 0.5;
-    }
-  }
+  cv::resize(result.segmentation, image, m1.size());
+  overLay(image, m1);
   return image;
 }


### PR DESCRIPTION
This pull request modifies the segmentation sample to resize the segmented output to the input resolution, rather than the other way around, since in the original case, the output is extremely small and it is impossible to see its details. Moreover, the original average function which uses two loops (one for row and one for column) to go over the pixels has been replaced with an equivalent function with only one loop over the indexes which is used in the [seg_and_pose_detect](https://github.com/Xilinx/Vitis-AI/blob/master/Vitis-AI-Library/demo/seg_and_pose_detect/seg_and_pose_detect.cpp) demo since it is much faster. The modified sample runs at 30-40 FPs on the ZCU104 board using the "seg_960_540.avi" demo file and 8 threads (-t 8).