### PR TITLE
Use --gpus all instead of --runtime nvidia

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -57,7 +57,7 @@ elif [[ $IMAGE_NAME == *"gpu"* ]]; then
     -w /workspace \
     -it \
     --rm \
-    --runtime=nvidia \
+    --gpus all \
     --network=host \
     $IMAGE_NAME \
     bash


### PR DESCRIPTION
With Docker 19.x this enables the gpu docker otherwise it fails
when using --runtime nvidia

$ docker --version
Docker version 19.03.5, build 633a0ea838
$ docker run --runtime=nvidia --rm nvidia/cuda:9.0-base nvidia-smi
docker: Error response from daemon: Unknown runtime specified nvidia.
See 'docker run --help'.
$ docker run --gpus all --rm nvidia/cuda:9.0-base nvidia-smi
Wed Jan  8 07:52:35 2020
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 440.44       Driver Version: 440.44       CUDA Version: 10.2     |
|-------------------------------+----------------------+----------------------+
....