### PR TITLE
Update alveo/README.md

### DIFF
--- a/alveo/README.md
+++ b/alveo/README.md
@@ -38,7 +38,6 @@ Then power cycle the system.
  
 ## References 
 - [Performance Whitepaper][]
-- [Accuracy Benchmarks](examples/caffe/Benchmark_README.md)
 - **Watch:** [Webinar on Xilinx FPGA Accelerated Inference][] 
 
 


### PR DESCRIPTION
Removing the Accuracy Bemchmarks link from alveo/README.md. 
This is already covered in https://github.com/Xilinx/Vitis-AI/blob/master/AI-Model-Zoo/README.md