### PR TITLE
[v1.3.2][vai_c_caffe] Pinned glog=0.4.0 to avoid undefined symbol error.

### DIFF
--- a/setup/docker/docker/cpu_conda/vitis-ai-caffe.yml
+++ b/setup/docker/docker/cpu_conda/vitis-ai-caffe.yml
@@ -28,3 +28,4 @@ dependencies:
   - ddump
   - vart
   - rt-engine
+  - glog=0.4.0

--- a/setup/docker/docker/gpu_conda/vitis-ai-caffe.yml
+++ b/setup/docker/docker/gpu_conda/vitis-ai-caffe.yml
@@ -28,3 +28,4 @@ dependencies:
   - ddump
   - vart
   - rt-engine
+  - glog=0.4.0


### PR DESCRIPTION
As seen in #512, undefined symbols occur in `vai_c_caffe` if `glog` version `0.5.0` is installed. `glog` has been pinned to `0.4.0` to avoid this issue.

I'm not sure if this needs to be applied to the other conda environments, or other versions of `vitis-ai`. Help is requested to check this.