### PR TITLE
Enable ROCm support for Tensorflow2.x

### DIFF
--- a/docker_run.sh
+++ b/docker_run.sh
@@ -51,6 +51,7 @@ VERSION=latest
 
 CPU_IMAGE_TAG=${DOCKER_REPO}${BRAND}-cpu:${VERSION}
 GPU_IMAGE_TAG=${DOCKER_REPO}${BRAND}-gpu:${VERSION}
+ROCM_IMAGE_TAG=${DOCKER_REPO}${BRAND}-rocm:${VERSION}
 IMAGE_NAME="${1:-$CPU_IMAGE_TAG}"
 DEFAULT_COMMAND="bash"
 
@@ -108,6 +109,10 @@ if [[ $IMAGE_NAME == *"gpu"* ]]; then
     $docker_devices \
     --gpus all \
     $docker_run_params
+elif [[ $IMAGE_NAME == *"rocm"* ]]; then
+    docker run \
+    --group-add=video --group-add=render --device=/dev/dri --device=/dev/kfd \
+    $docker_run_params	   
 else
   docker run \
     $docker_devices \

--- a/setup/docker/docker/DockerfileROCm
+++ b/setup/docker/docker/DockerfileROCm
@@ -1,0 +1,320 @@
+FROM rocm/dev-ubuntu-18.04:4.2-complete
+env DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-c"]
+ENV TZ=America/Denver
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV VAI_ROOT=/opt/vitis_ai
+ENV VAI_HOME=/vitis_ai_home
+ARG VERSION
+ENV VERSION=$VERSION
+ARG GIT_HASH="<blank>"
+ENV GIT_HASH=$GIT_HASH
+ARG DATE
+ENV DATE=$DATE
+ARG XRT_URL=https://www.xilinx.com/bin/public/openDownload?filename=xrt_202110.2.11.648_18.04-amd64-xrt.deb
+ENV XRT_URL=$XRT_URL
+ARG XRM_URL=https://www.xilinx.com/bin/public/openDownload?filename=xrm_202110.1.2.1539_18.04-x86_64.deb
+ENV XRM_URL=$XRM_URL
+ARG PETALINUX_URL=https://www.xilinx.com/bin/public/openDownload?filename=sdk-2021.1.0.0.sh
+ENV PETALINUX_URL=$PETALINUX_URL
+ARG VAI_CONDA_CHANNEL="file:///scratch/conda-channel"
+ENV VAI_CONDA_CHANNEL=$VAI_CONDA_CHANNEL
+ARG VAI_DEB_CHANNEL=""
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+RUN chmod 1777 /tmp \
+    && mkdir /scratch \
+    && chmod 1777 /scratch \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        autoconf \
+        automake \
+        bc \
+        build-essential \
+        bzip2 \
+        ca-certificates \
+        curl \
+        g++ \
+        gdb \
+        git \
+        gnupg \
+        libboost-all-dev \
+        libgflags-dev \
+        libgoogle-glog-dev \
+        libgtest-dev \
+        libjson-c-dev \
+        libjsoncpp-dev \
+        libssl-dev \
+        libtool \
+        libunwind-dev \
+        locales \
+        make \
+        openssh-client \
+        openssl \
+        python3 \
+        python3-dev \
+        python3-minimal \
+        python3-numpy \
+        python3-pip \
+        python3-setuptools \
+        python3-venv \
+        software-properties-common \
+        sudo \
+        tree \
+        unzip \
+        vim \
+        wget \
+        yasm \
+        zstd
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen \
+    && echo "LC_ALL=en_US.UTF-8" >> /etc/environment \
+    && echo "LANG=en_US.UTF-8" > /etc/locale.conf \
+    && locale-gen en_US.UTF-8 \
+    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 \
+    && dpkg-reconfigure locales
+
+# Tools for building vitis-ai-library in the docker container
+RUN apt-get -y install \
+        libgtest-dev \
+        libeigen3-dev \
+        rpm \
+        libavcodec-dev \
+        libavformat-dev \
+        libswscale-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libgstreamer1.0-dev \
+        libgtk-3-dev \
+        libpng-dev \
+        libjpeg-dev \
+        libopenexr-dev \
+        libtiff-dev \
+        libwebp-dev \
+        libgtk2.0-dev \
+        libhdf5-dev \
+        opencl-clhpp-headers \
+        opencl-headers \
+        pocl-opencl-icd \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt install -y gcc-8 g++-8 gcc-9 g++-9 \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null \
+    && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' \
+    && apt-get update -y \
+    && apt-get install -y \
+        cmake=3.16.0-0kitware1 \
+        cmake-data=3.16.0-0kitware1 \
+        kitware-archive-keyring \
+    && apt-get install -y ffmpeg \
+    && cd /usr/src/gtest \
+    && mkdir -p build \
+    && cd build \
+    && cmake .. \
+    && make \
+    && make install
+
+RUN pip3 install \
+        Flask \
+        setuptools \
+        wheel
+
+# Install XRT
+RUN wget --progress=dot:mega -O xrt.deb ${XRT_URL} \
+    && ls -lhd ./xrt.deb \
+    && apt-get update -y \
+    && apt-get install -y ./xrt.deb \
+    && rm -fr /tmp/*
+
+# Install XRM
+RUN wget --progress=dot:mega -O xrm.deb ${XRM_URL} \
+    && ls -lhd ./xrm.deb \
+    && apt-get install -y ./xrm.deb \
+    && rm -fr /tmp/*
+
+# glog 0.4.0
+RUN cd /tmp \
+    && wget --progress=dot:mega -O glog.0.4.0.tar.gz https://codeload.github.com/google/glog/tar.gz/v0.4.0 \
+    && tar -xvf glog.0.4.0.tar.gz \
+    && cd glog-0.4.0 \
+    && ./autogen.sh \
+    && mkdir build \
+    && cd build \
+    && cmake -DBUILD_SHARED_LIBS=ON .. \
+    && make -j \
+    && make install \
+    && rm -fr /tmp/*
+
+# protobuf 3.4.0
+RUN cd /tmp; wget --progress=dot:mega https://codeload.github.com/google/protobuf/zip/v3.4.0 \
+    && unzip v3.4.0 \
+    && cd protobuf-3.4.0 \
+    && ./autogen.sh \
+    && ./configure \
+    && make -j \
+    && make install \
+    && ldconfig \
+    && rm -fr /tmp/*
+
+# opencv 3.4.3
+RUN export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    && cd /tmp; wget --progress=dot:mega https://github.com/opencv/opencv/archive/3.4.3.tar.gz \
+    && tar -xvf 3.4.3.tar.gz \
+    && cd opencv-3.4.3 \
+    && mkdir build \
+    && cd build \
+    && cmake -DBUILD_SHARED_LIBS=ON .. \
+    && make -j \
+    && make install \
+    && ldconfig \
+    && export PATH="${VAI_ROOT}/conda/bin:${VAI_ROOT}/utility:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+    && rm -fr /tmp/*
+
+# gflags 2.2.2
+RUN cd /tmp; wget --progress=dot:mega https://github.com/gflags/gflags/archive/v2.2.2.tar.gz \
+    && tar xvf v2.2.2.tar.gz \
+    && cd gflags-2.2.2 \
+    && mkdir build \
+    && cd build \
+    && cmake -DBUILD_SHARED_LIBS=ON .. \
+    && make -j \
+    && make install \
+    && rm -fr /tmp/*
+
+# pybind 2.5.0
+RUN cd /tmp; git clone https://github.com/pybind/pybind11.git \
+    && cd pybind11 \
+    && git checkout v2.5.0 \
+    && mkdir build \
+    && cd build \
+    && cmake -DPYBIND11_TEST=OFF .. \
+    && make \
+    && make install \
+    && rm -fr /tmp/* \
+    && chmod 777 /usr/lib/python3/dist-packages
+
+RUN cd /tmp; wget --progress=dot:mega http://launchpadlibrarian.net/436533799/libjson-c4_0.13.1+dfsg-4_amd64.deb \
+    && dpkg -i ./libjson-c4_0.13.1+dfsg-4_amd64.deb \
+    && rm -fr /tmp/*
+
+RUN echo $VERSION > /etc/VERSION.txt
+
+ENV GOSU_VERSION 1.12
+
+COPY docker/bashrc /etc/bash.bashrc
+RUN chmod a+rwx /etc/bash.bashrc
+RUN groupadd vitis-ai-group \
+    && useradd --shell /bin/bash -c '' -m -g vitis-ai-group vitis-ai-user \
+    && passwd -d vitis-ai-user \
+    && addgroup --gid 109 render \
+    && usermod -aG sudo vitis-ai-user \
+    && usermod -aG video vitis-ai-user \
+    && usermod -aG render vitis-ai-user \    
+    && echo 'ALL ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers \
+    && echo 'Defaults        secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/vitis_ai/conda/bin"' >> /etc/sudoers \
+    && curl -sSkLo /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && chmod +x /usr/local/bin/gosu \
+    && echo ". $VAI_ROOT/conda/etc/profile.d/conda.sh" >> ~vitis-ai-user/.bashrc \
+    && echo "conda activate base" >> ~vitis-ai-user/.bashrc \
+    && echo "export VERSION=${VERSION}" >> ~vitis-ai-user/.bashrc \
+    && echo "export BUILD_DATE=\"${DATE}\"" >> ~vitis-ai-user/.bashrc \
+    && echo "export GIT_HASH=${GIT_HASH}" >> ~vitis-ai-user/.bashrc \
+    && cat ~vitis-ai-user/.bashrc >> /root/.bashrc \
+    && echo $VERSION > /etc/VERSION.txt \
+    && echo $DATE > /etc/BUILD_DATE.txt \
+    && echo $GIT_HASH > /etc/GIT_HASH.txt \
+    && echo 'export PS1="\[\e[91m\]Vitis-AI\[\e[m\] \w > "' >> ~vitis-ai-user/.bashrc \
+    && mkdir -p ${VAI_ROOT} \
+    && chown -R vitis-ai-user:vitis-ai-group ${VAI_ROOT} \
+    && mkdir /etc/conda \
+    && touch /etc/conda/condarc \
+    && chmod 777 /etc/conda/condarc \
+    && cat /etc/conda/condarc \
+    && mkdir -p ${VAI_ROOT}/scripts \
+    && chmod 775 ${VAI_ROOT}/scripts
+
+COPY docker/host_cross_compiler_setup.sh ${VAI_ROOT}/scripts/
+RUN chmod a+rx ${VAI_ROOT}/scripts/host_cross_compiler_setup.sh
+
+COPY docker/replace_pytorch.sh ${VAI_ROOT}/scripts/
+RUN chmod a+rx ${VAI_ROOT}/scripts/replace_pytorch.sh
+
+# Set up Anaconda
+USER vitis-ai-user
+
+RUN cd /tmp \
+    && wget --progress=dot:mega https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh \
+    && /bin/bash ./miniconda.sh -b -p $VAI_ROOT/conda \
+    && echo "channels:" >> /etc/conda/condarc \
+    && echo "  - ${VAI_CONDA_CHANNEL}" >> /etc/conda/condarc \
+    && sudo ln -s $VAI_ROOT/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
+ADD --chown=vitis-ai-user:vitis-ai-group docker/rocm_conda/*.yml /scratch/
+ADD --chown=vitis-ai-user:vitis-ai-group docker/pip_requirements.txt /scratch/
+
+# Rebuild this layer every time
+ARG CACHEBUST=1
+
+RUN cd /scratch/ \
+    && wget -O conda-channel.tar.gz --progress=dot:mega https://www.xilinx.com/bin/public/openDownload?filename=conda-channel_1.4.1.978-01.tar.gz \
+    && tar -xzvf conda-channel.tar.gz \
+    && . $VAI_ROOT/conda/etc/profile.d/conda.sh \
+    && conda install -c defaults conda-build \
+    && python3 -m pip install --upgrade pip wheel setuptools \
+    && conda env create -f /scratch/vitis-ai-pytorch.yml \
+        && conda activate vitis-ai-pytorch \
+        && pip install -r /scratch/pip_requirements.txt \
+    && conda env create -f /scratch/vitis-ai-rocm-tensorflow2.3.yml \
+        && conda activate vitis-ai-rocm-tensorflow2.3 \
+        && pip install -r /scratch/pip_requirements.txt \
+	&& pip install --ignore-installed tensorflow-rocm==2.3.7 \
+    && conda env create -f /scratch/vitis-ai-rocm-tensorflow2.4.yml \
+        && conda activate vitis-ai-rocm-tensorflow2.4 \
+	&& pip install -r /scratch/pip_requirements.txt \
+        && pip install --ignore-installed tensorflow-rocm==2.4.3 \
+    && conda env create -f /scratch/vitis-ai-rocm-tensorflow2.5.yml \
+        && conda activate vitis-ai-rocm-tensorflow2.5 \
+	&& pip install -r /scratch/pip_requirements.txt \
+        && pip install --ignore-installed tensorflow-rocm==2.5.0 \
+    && rm -fr /scratch/*	
+
+USER root
+# VAI-1372: Workaround to fix GCC 9 in vitis-ai-tensorflow
+RUN rm -f /opt/vitis_ai/conda/envs/vitis-ai-tensorflow/etc/conda/activate.d/activate-binutils_linux-64.sh \
+    && rm -f /opt/vitis_ai/conda/envs/vitis-ai-tensorflow/etc/conda/activate.d/activate-gcc_linux-64.sh \
+    && rm -f /opt/vitis_ai/conda/envs/vitis-ai-tensorflow/etc/conda/activate.d/activate-gxx_linux-64.sh \
+    && rm -f /opt/vitis_ai/conda/envs/vitis-ai-tensorflow/etc/conda/deactivate.d/deactivate-binutils_linux-64.sh \
+    && rm -f /opt/vitis_ai/conda/envs/vitis-ai-tensorflow/etc/conda/deactivate.d/deactivate-gcc_linux-64.sh \
+    && rm -f /opt/vitis_ai/conda/envs/vitis-ai-tensorflow/etc/conda/deactivate.d/deactivate-gxx_linux-64.sh
+
+# Rebuild this layer every time
+ARG CACHEBUST=1
+RUN cd /tmp/ \
+    && wget -O libunilog.deb https://www.xilinx.com/bin/public/openDownload?filename=libunilog_1.4.1-r82_amd64.deb \
+    && wget -O libtarget-factory.deb https://www.xilinx.com/bin/public/openDownload?filename=libtarget-factory_1.4.1-r85_amd64.deb \
+    && wget -O libxir.deb https://www.xilinx.com/bin/public/openDownload?filename=libxir_1.4.1-r91_amd64.deb \
+    && wget -O libvart.deb https://www.xilinx.com/bin/public/openDownload?filename=libvart_1.4.1-r130_amd64.deb \
+    && wget -O libvitis_ai_library.deb https://www.xilinx.com/bin/public/openDownload?filename=libvitis_ai_library_1.4.1-r114_amd64.deb \
+    && wget -O librt-engine.deb https://www.xilinx.com/bin/public/openDownload?filename=librt-engine_1.4.1-r195_amd64.deb \
+    && wget -O aks.deb https://www.xilinx.com/bin/public/openDownload?filename=aks_1.4.1-r78_amd64.deb \
+    && apt-get install -y --no-install-recommends /tmp/*.deb \
+    && rm -rf /tmp/* \
+    && ldconfig
+
+RUN apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /scratch/*
+
+# Set default build toolchain to GCC 9 for better performance
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-9 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-9 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 80 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-8 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 70 \
+        --slave /usr/bin/g++ g++ /usr/bin/g++-7 \
+        --slave /usr/bin/gcov gcov /usr/bin/gcov-7
+
+COPY docker/banner_rocm.sh /etc/banner.sh

--- a/setup/docker/docker/banner_rocm.sh
+++ b/setup/docker/docker/banner_rocm.sh
@@ -1,0 +1,21 @@
+echo -e "\e[1;90m
+==========================================
+\e[m \e[1;91m
+__      ___ _   _                   _____
+\ \    / (_) | (_)            /\   |_   _|
+ \ \  / / _| |_ _ ___ ______ /  \    | |
+  \ \/ / | | __| / __|______/ /\ \   | |
+   \  /  | | |_| \__ \     / ____ \ _| |_
+    \/   |_|\__|_|___/    /_/    \_\_____|
+\e[m \e[1;90m
+==========================================
+\e[m"
+echo -e "Docker Image Version: \e[32m $VERSION \e[m"
+echo -e "Vitis AI Git Hash: \e[32m $GIT_HASH \e[m"
+echo "Build Date: $BUILD_DATE"
+echo -e ""
+echo -e "For PyTorch Workflows do:"
+echo -e "    \e[31m conda activate vitis-ai-pytorch \e[m"
+echo -e "For ROCm TensorFlow 2.3 Workflows do:"
+echo -e "    \e[31m conda activate vitis-ai-rocm-tensorflow2.3 \e[m"
+echo -e ""

--- a/setup/docker/docker/rocm_conda/vitis-ai-pytorch.yml
+++ b/setup/docker/docker/rocm_conda/vitis-ai-pytorch.yml
@@ -1,0 +1,24 @@
+name: vitis-ai-pytorch
+
+channels:
+  - pytorch
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.6
+  - pytorch_nndct
+  - pydot
+  - pyyaml
+  - jupyter
+  - ipywidgets
+  - dill
+  - progressbar2
+  - pytest
+  - scikit-learn
+  - pandas
+  - matplotlib
+  - pillow
+  - vaic
+  - vart
+  - rt-engine

--- a/setup/docker/docker/rocm_conda/vitis-ai-rocm-tensorflow2.3.yml
+++ b/setup/docker/docker/rocm_conda/vitis-ai-rocm-tensorflow2.3.yml
@@ -1,0 +1,23 @@
+name: vitis-ai-rocm-tensorflow2.3
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.7
+  - vai_q_tensorflow2
+  - pydot
+  - pyyaml
+  - jupyter
+  - ipywidgets
+  - dill
+  - progressbar2
+  - pytest
+  - scikit-learn
+  - pandas
+  - matplotlib
+  - pillow
+  - vaic
+  - vart
+  - rt-engine

--- a/setup/docker/docker/rocm_conda/vitis-ai-rocm-tensorflow2.4.yml
+++ b/setup/docker/docker/rocm_conda/vitis-ai-rocm-tensorflow2.4.yml
@@ -1,0 +1,23 @@
+name: vitis-ai-rocm-tensorflow2.4
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.7
+  - vai_q_tensorflow2
+  - pydot
+  - pyyaml
+  - jupyter
+  - ipywidgets
+  - dill
+  - progressbar2
+  - pytest
+  - scikit-learn
+  - pandas
+  - matplotlib
+  - pillow
+  - vaic
+  - vart
+  - rt-engine

--- a/setup/docker/docker/rocm_conda/vitis-ai-rocm-tensorflow2.5.yml
+++ b/setup/docker/docker/rocm_conda/vitis-ai-rocm-tensorflow2.5.yml
@@ -1,0 +1,23 @@
+name: vitis-ai-rocm-tensorflow2.5
+
+channels:
+  - conda-forge
+  - defaults
+
+dependencies:
+  - python=3.7
+  - vai_q_tensorflow2
+  - pydot
+  - pyyaml
+  - jupyter
+  - ipywidgets
+  - dill
+  - progressbar2
+  - pytest
+  - scikit-learn
+  - pandas
+  - matplotlib
+  - pillow
+  - vaic
+  - vart
+  - rt-engine

--- a/setup/docker/docker_build_rocm.sh
+++ b/setup/docker/docker_build_rocm.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Copyright 2020 Xilinx Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_REPO="${DOCKER_REPO:-xilinx/}"
+VERSION="${VERSION:-`cat docker/VERSION.txt`}"
+DOCKERFILE="${DOCKERFILE:-docker/DockerfileROCm}"
+XRT_URL="${XRT_URL:-https://www.xilinx.com/bin/public/openDownload?filename=xrt_202110.2.11.648_18.04-amd64-xrt.deb}"
+XRM_URL="${XRT_URL:-https://www.xilinx.com/bin/public/openDownload?filename=xrm_202110.1.2.1539_18.04-x86_64.deb}"
+PETALINUX_URL="${XRT_URL:-https://www.xilinx.com/bin/public/openDownload?filename=sdk-2021.1.0.0.sh}"
+
+
+BRAND="${BRAND:-vitis-ai-rocm}"
+DATE="$(date)"
+
+# Final Build Image Tag
+IMAGE_TAG=${DOCKER_REPO}${BRAND}:${VERSION}
+IMAGE_LATEST_TAG=${DOCKER_REPO}${BRAND}:latest
+
+docker build --network=host --build-arg VERSION=${VERSION} --build-arg GIT_HASH=`git rev-parse --short HEAD` --build-arg CACHEBUST="$(date +%s)" --build-arg DATE="$(date -I)" -f ${DOCKERFILE} -t ${IMAGE_TAG} ./
+docker tag ${IMAGE_TAG} ${IMAGE_LATEST_TAG}


### PR DESCRIPTION
ROCm enablement for Quantizer Tensorflow2.x support:

- Adds DockerfileROCm recipe to build xilinx/vitis-ai-rocm docker image
- Adds flags needed in docker_run.sh to run ROCm docker image
- Adds conda environment for ROCm Tensorflow 2.3 running on ROCm 4.2.

Note: Pytorch is created as a conda environment in DockerfileROCm but not yet functional for ROCm Pytorch. 