### PR TITLE
Make docker_run.sh remember accepted terms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.docker_run_terms_status

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -1,38 +1,41 @@
 #!/bin/bash
 # Copyright 2020 Xilinx Inc.
 
-sed -n '1, 5p' ./setup/docker/docker/PROMPT.txt
-read -n 1 -s -r -p "Press any key to continue..." key
+print_terms() {
+  sed -n '1, 5p' ./setup/docker/docker/PROMPT.txt
+  read -n 1 -s -r -p "Press any key to continue..." key
 
-sed -n '5, 15p' ./setup/docker/docker/PROMPT.txt
-read -n 1 -s -r -p "Press any key to continue..." key
+  sed -n '5, 15p' ./setup/docker/docker/PROMPT.txt
+  read -n 1 -s -r -p "Press any key to continue..." key
 
-sed -n '15, 28p' ./setup/docker/docker/PROMPT.txt
-read -n 1 -s -r -p "Press any key to continue..." key
+  sed -n '15, 28p' ./setup/docker/docker/PROMPT.txt
+  read -n 1 -s -r -p "Press any key to continue..." key
 
-sed -n '28, 61p' ./setup/docker/docker/PROMPT.txt
-read -n 1 -s -r -p "Press any key to continue..." key
+  sed -n '28, 61p' ./setup/docker/docker/PROMPT.txt
+  read -n 1 -s -r -p "Press any key to continue..." key
 
-sed -n '62, 224p' ./setup/docker/docker/PROMPT.txt
-read -n 1 -s -r -p "Press any key to continue..." key
+  sed -n '62, 224p' ./setup/docker/docker/PROMPT.txt
+  read -n 1 -s -r -p "Press any key to continue..." key
 
-sed -n '224, 308p' ./setup/docker/docker/PROMPT.txt
-read -n 1 -s -r -p "Press any key to continue..." key
-
+  sed -n '224, 308p' ./setup/docker/docker/PROMPT.txt
+  read -n 1 -s -r -p "Press any key to continue..." key
+}
 
 confirm() {
   echo -en "\n\nDo you agree to the terms and wish to proceed [y/n]? "
   read REPLY
   case $REPLY in
-    [Yy]) ;;
+    [Yy]) echo "accepted" > .docker_run_terms_status ;;
     [Nn]) exit 0 ;;
     *) confirm ;;
   esac
     REPLY=''
 }
 
-confirm
-
+if [[ `test -f .docker_run_terms_status && cat .docker_run_terms_status` != "accepted" ]]; then
+  print_terms
+  confirm
+fi
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "Usage: $0 <image>"


### PR DESCRIPTION
Small change that makes `docker_run.sh` remember once the terms were accepted. So, it no longer displays it at each run. :smile: