### PR TITLE
added ROCm support for pytorch_nndct module

### DIFF
--- a/tools/Vitis-AI-Quantizer/vai_q_pytorch/README.md
+++ b/tools/Vitis-AI-Quantizer/vai_q_pytorch/README.md
@@ -70,6 +70,11 @@ For CPU version, remove all CUDA_HOME environment variable setting in your .bash
 
     unset CUDA_HOME
 
+To use HIP, you need to set your ROCm home and CPPFLAGS environment variables.
+
+    export ROCM_HOME=/opt/rocm
+    export CPPFLAGS=$(hipconfig --cpp_config)
+
 ##### Pre step 2: install Pytorch(1.1-1.7.1) and torchvision
 Here take pytorch 1.7.1 and torchvision 0.8.2 as an example, detailed instructions for other versions are in [pytorch](https://pytorch.org/) website.
 

--- a/tools/Vitis-AI-Quantizer/vai_q_pytorch/csrc/cuda/nndct_cuda_math.cu
+++ b/tools/Vitis-AI-Quantizer/vai_q_pytorch/csrc/cuda/nndct_cuda_math.cu
@@ -18,10 +18,16 @@
 
 #include <math.h>
 #include <algorithm>
-#include <math_constants.h>
 #include "../../include/cuda/nndct_fix_kernels.cuh"
 #include "../../include/cuda/nndct_cu_utils.h"
 #include "../../include/cuda/nndct_cuda_math.h"
+
+#ifdef __HIP_PLATFORM_AMD__
+#define CUDART_INF_F            __int_as_float(0x7f800000)
+#define CUDART_INF              __longlong_as_double(0x7ff0000000000000ULL)
+#else
+#include <math_constants.h>
+#endif
 
 template<typename Dtype>
 __global__ static void _set(const int N, 

--- a/tools/Vitis-AI-Quantizer/vai_q_pytorch/include/cuda/nndct_cu_utils.h
+++ b/tools/Vitis-AI-Quantizer/vai_q_pytorch/include/cuda/nndct_cu_utils.h
@@ -1,32 +1,35 @@
-
-
 /*
-* Copyright 2019 Xilinx Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
+ *
+ * * Copyright 2019 Xilinx Inc.
+ * *
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * * you may not use this file except in compliance with the License.
+ * * You may obtain a copy of the License at
+ * *
+ * *     http://www.apache.org/licenses/LICENSE-2.0
+ * *
+ * * Unless required by applicable law or agreed to in writing, software
+ * * distributed under the License is distributed on an "AS IS" BASIS,
+ * * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * * See the License for the specific language governing permissions and
+ * * limitations under the License.
+ * */
 
 #ifndef _NNDCT_CU_UTILS_H_
 #define _NNDCT_CU_UTILS_H_
-#include <cuda.h>
-#include <cuda_runtime.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <algorithm>
 #include <assert.h>
+
+#ifdef __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+#else
+#include <cuda.h>
+#include <cuda_runtime.h>
+#endif
 
 #define BLOCKSIZE_COL 64
 #define BLOCKSIZE_ROW 4
@@ -37,33 +40,28 @@
 
 #define NNDCT_KERNEL_LOOP(i, n) \
   for (int i = blockIdx.x * blockDim.x + threadIdx.x; \
-       i < (n); \
-       i += blockDim.x * gridDim.x)
-
-
+		  i < (n); \
+		  i += blockDim.x * gridDim.x)
 
 inline int NNDCT_GET_BLOCKS(const int N){
-  return (N + NNDCT_CUDA_NUM_THREADS - 1) / NNDCT_CUDA_NUM_THREADS;
+	return (N + NNDCT_CUDA_NUM_THREADS - 1) / NNDCT_CUDA_NUM_THREADS;
 }
 
 inline int n_blocks(int size, int block_size) {
-  return size / block_size + ((size % block_size == 0)? 0 : 1);
+	return size / block_size + ((size % block_size == 0)? 0 : 1);
 }
 
 inline int NNDCT_GET_BLOCKS1D(const int N){
-  int dimGrid = n_blocks(N, CU1DBLOCK);
-  if (dimGrid > 256) {
-    dimGrid = 256;
-  }
-  return dimGrid;
+	int dimGrid = n_blocks(N, CU1DBLOCK);
+	if (dimGrid > 256) {
+		dimGrid = 256;
+	}
+	return dimGrid;
 }
 
 dim3 GetGridSizeF(unsigned n);
 
 void GetBlockSizesForSimpleMatrixOperation(int num_rows,
-    int num_cols,dim3 *dimGrid,dim3 *dimBlock);
-
-
-
+		int num_cols,dim3 *dimGrid,dim3 *dimBlock);
 
 #endif //_NNDCT_CU_UTILS_H_

--- a/tools/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/nn/load_kernels.py
+++ b/tools/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/nn/load_kernels.py
@@ -62,7 +62,7 @@ else:
     ]
     
     with_cuda = False
-    #if torch.cuda.is_available() and "CUDA_HOME" in os.environ:
+    extra_cflags = ""
     if "CUDA_HOME" in os.environ:
       cuda_src_path = os.path.join(cwd, "../../../csrc/cuda")
       for name in os.listdir(cuda_src_path):
@@ -76,8 +76,22 @@ else:
       
       extra_include_paths.append(os.path.join(cwd, "../../../include/cuda"))
       with_cuda = None
+    elif "ROCM_HOME" in os.environ:
+      hip_src_path = os.path.join(cwd, "../../../csrc/cuda")
+      for name in os.listdir(hip_src_path):
+        if name.split(".")[-1] in ["cu", "cpp", "cc", "c"]:
+          source_files.append(os.path.join(hip_src_path, name))
+          
+      cpp_src_path = os.path.join(cwd, "src/cuda")
+      for name in os.listdir(cpp_src_path):
+        if name.split(".")[-1] in ["cpp", "cc", "c"]:
+          source_files.append(os.path.join(cpp_src_path, name))
+      
+      extra_include_paths.append(os.path.join(cwd, "../../../include/cuda"))
+      extra_cflags = os.environ.get('CPPFLAGS')
+      with_cuda = None
     else:
-      print("CUDA is not available, or CUDA_HOME not found in the environment " 
+      print("CUDA (HIP) is not available, or CUDA_HOME (ROCM_HOME) not found in the environment " 
           "so building without GPU support.")
       cpp_src_path = os.path.join(cwd, "src/cpu")
       for name in os.listdir(cpp_src_path):
@@ -89,9 +103,10 @@ else:
         sources=source_files,
         verbose=False,
         build_directory=lib_path,
+        extra_cflags=[extra_cflags],
         extra_include_paths=extra_include_paths,
         with_cuda=with_cuda)
-    
+
   except ImportError as e:
     NndctScreenLogger().error(f"{str(e)}")
     sys.exit(1)

--- a/tools/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/qproc/base.py
+++ b/tools/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/qproc/base.py
@@ -91,9 +91,9 @@ class TorchQuantProcessor():
     
     # Check device available
     if device.type == "cuda":
-      if not (torch.cuda.is_available() and "CUDA_HOME" in os.environ):
+      if not (torch.cuda.is_available() and "CUDA_HOME" or "ROCM_HOME" in os.environ):
         device = torch.device("cpu")
-        NndctScreenLogger().warning(f"CUDA is not available, change device to CPU")
+        NndctScreenLogger().warning(f"CUDA (HIP) is not available, change device to CPU")
     
     # Transform torch module to quantized module format
     nndct_utils.create_work_dir(output_dir)

--- a/tools/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/qproc/rnn.py
+++ b/tools/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/qproc/rnn.py
@@ -62,9 +62,9 @@ class LSTMTorchQuantProcessor(TorchQuantProcessor):
     
     # Check device available
     if device.type == "cuda":
-      if not (torch.cuda.is_available() and "CUDA_HOME" in os.environ):
+      if not (torch.cuda.is_available() and "CUDA_HOME" or "ROCM_HOME" in os.environ):
         device = torch.device("cpu")
-        NndctScreenLogger().warning(f"CUDA is not available, change device to CPU")
+        NndctScreenLogger().warning(f"CUDA (HIP) is not available, change device to CPU")
     
     # Transform torch module to quantized module format
     nndct_utils.create_work_dir(output_dir)


### PR DESCRIPTION
This PR was checked by running the resnet18_quant.py example following the README instructions.  The example ran successfully and the AMD GPUs reported activity during the run with the command "rocm-smi" and thus, this test showed the use of ROCm as the backened stack. 

This is accomplished by the JIT compilation generating "hipified" code from the cuda source files and therefore, is done with minor change to the code base.  

The major change was adding "extra_cflags" to the cpp_extension load call in vai_q_pytorch/pytorch_binding/pytorch_nndct_nn/load_kernels.py.  This flag takes in the environment variable "__HIP_PLATFORM_AMD__", which is used for specific include statements in "vai_q_pytorch/include/cuda/nn_cu_utils.h" and in "vai_q_pytorch/csrc/cuda/nndct_cuda_math.cu".  The README now has simple commands needed to set this and the ROCM_HOME environment variables for all of this to work.  

The solution above is not ideal.  Ideally, we would like hipify to generate the associated include/hip folders from the include/cuda code as well and the associated src/hip code having the correct include paths.  This is how newer versions of hipify-torch works but this requires newer versions of PyTorch that is not yet supported by Vitis-AI.