### PR TITLE
A few source fixes to make VAI 2.0 buildable on Ubuntu. 

### DIFF
--- a/tools/Vitis-AI-Library/clocs/src/utils.hpp
+++ b/tools/Vitis-AI-Library/clocs/src/utils.hpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <vector>
+using namespace std;
 using std::vector;
 namespace vitis {
 namespace ai {

--- a/tools/Vitis-AI-Library/cpu_task/test/cxxopts.hpp
+++ b/tools/Vitis-AI-Library/cpu_task/test/cxxopts.hpp
@@ -44,6 +44,7 @@ THE SOFTWARE.
 #include <cctype>
 #include <exception>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <memory>
 #include <regex>


### PR DESCRIPTION
Missing `<limits>` inclusion and a missing namespace usage to to not fail when trying to use `size_t` as-is.

Not sure if those are all the fixes needed to get 2.0 buildable, but at least these made the build progress compilation-wise.