### PR TITLE
Fix for Nvidia CUDA-LINUX repository key rotation

### DIFF
--- a/setup/docker/dockerfiles/vitis-ai-gpu.Dockerfile
+++ b/setup/docker/dockerfiles/vitis-ai-gpu.Dockerfile
@@ -26,6 +26,19 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+RUN set -x \
+    && apt-key list \
+    && ls -al /etc/apt/sources.list.d/ \
+    # Remove the CUDA Tools Public Key which is outdated \
+    && apt-key del 7fa2af80 \
+    # Fetch the new CUDA Public Key \
+    && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/3bf863cc.pub \
+    && apt-key list \
+    # Fetch the NVIDIA ML Key \
+    && apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub \
+    && apt-key list \
+    && apt-get update -y
+
 RUN chmod 1777 /tmp \
     && mkdir /scratch \
     && chmod 1777 /scratch \


### PR DESCRIPTION
The modifications made to this file correct an issue when attempting to build the GPU docker (./docker_build_gpu.sh).  Specifically, the error that arises during the build is:  

Get:5 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages [1496 kB]
Err:2 https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64 InRelease
 The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC

This issue results from a very recent change that Nvidia made in order to rotate their Public key:  https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772

@hanxue @andyluo7 