### PR TITLE
the_factory_methods static variable have initialization order issue

### DIFF
--- a/src/Vitis-AI-Runtime/VART/vart/xrt-device-handle/src/xrt_device_handle.cpp
+++ b/src/Vitis-AI-Runtime/VART/vart/xrt-device-handle/src/xrt_device_handle.cpp
@@ -22,26 +22,31 @@ DEF_ENV_PARAM(DEBUG_XRT_DEVICE_HANDLE, "0");
 
 namespace xir {
 
-static std::map<std::string, std::function<std::shared_ptr<XrtDeviceHandle>()>>
-    the_factory_methods;
+static std::map<std::string, std::function<std::shared_ptr<XrtDeviceHandle>()>>& get_factory_methods()
+{
+    static std::map<std::string, std::function<std::shared_ptr<XrtDeviceHandle>()>>
+        the_factory_methods;
+    return the_factory_methods;
+}
 
 void XrtDeviceHandle::registar(
     const std::string& name,
     std::function<std::shared_ptr<XrtDeviceHandle>()> m) {
-  auto it = the_factory_methods.begin();
+
+  auto it = get_factory_methods().begin();
   auto ok = false;
-  std::tie(it, ok) = the_factory_methods.emplace(std::make_pair(name, m));
+  std::tie(it, ok) = get_factory_methods().emplace(std::make_pair(name, m));
   LOG_IF(INFO, ENV_PARAM(DEBUG_XRT_DEVICE_HANDLE))
       << "add factory method " << name;
   CHECK(ok);
 }
 
 std::shared_ptr<XrtDeviceHandle> XrtDeviceHandle::get_instance() {
-  CHECK(!the_factory_methods.empty());
-  auto ret = the_factory_methods.begin()->second();
+  CHECK(!get_factory_methods().empty());
+  auto ret = get_factory_methods().begin()->second();
   LOG_IF(INFO, ENV_PARAM(DEBUG_XRT_DEVICE_HANDLE))
       << "return the xrt handle instance via "
-      << the_factory_methods.begin()->first << " "
+      << get_factory_methods().begin()->first << " "
       << " ret=" << (void*)ret.get();
   return ret;
 }


### PR DESCRIPTION
This patch fix 2 locations but the issue is the same. Let's takes xrt-device-handle as example.

the_factory_methods is originally a static variable. But looking at its consumer, there are 2 places that will call registar() to manipulate the static variables, they are:
src/Vitis-AI-Runtime/VART/vart/xrt-device-handle/src/xrt_device_handle_butler.cpp
src/Vitis-AI-Runtime/VART/vart/xrt-device-handle/src/xrt_device_handle_imp.cpp

Both files contain the g_registar variable which is also static but it will call the registar() which manipulate the_factory_methods variable.

Since both variables are static, there are no guarantee on which one will be instantiated. So there may be crash in certain scenario.

Ref: https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use 