### PR TITLE
Fix PyTorch QAT .deployable_model(used_for_xmodel=True) To Support Tuple & List Inputs

### DIFF
--- a/src/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/quantization/quant_aware_training.py
+++ b/src/Vitis-AI-Quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/quantization/quant_aware_training.py
@@ -452,7 +452,10 @@ class QatProcessor(object):
   def deployable_model(self, src_dir, used_for_xmodel=False):
     if used_for_xmodel:
       device = torch.device('cpu')
-      inputs = self._inputs.to(device)
+      if isinstance(self._inputs, torch.Tensor):
+        inputs = self._inputs.to(device)
+      elif isinstance(self._inputs, tuple) or isinstance(self._inputs, list):
+        inputs = type(self._inputs)(map(lambda x: x.to(device), self._inputs))
     else:
       device = self._device
       inputs = self._inputs


### PR DESCRIPTION
### Issue:
Currently, when QatProcessor.deployable_model() is called with used_for_xmodel=True, it only considers the case where self._inputs is a torch.Tensor. If self._inputs is a tuple or list of torch.Tensors, this fails.

### Fix:
Call .to(device) on each torch.Tensor in the tuple/list.