### PR TITLE
BUGFIX: Modify the sources to be compiled for Zynq-7000 devices

### DIFF
--- a/src/Vitis-AI-Library/math/src/image_util.cpp
+++ b/src/Vitis-AI-Library/math/src/image_util.cpp
@@ -548,10 +548,52 @@ void transform_mean_scale(int w, int h, const uint8_t* src, int8_t* dst,
       // vabdq_u8(in_u8, low_mean)), scale);
       return int8x16_t();
     } else if (scale < 0) {
-      // scale < 0
-      return vreinterpretq_s8_u8(
-          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), -scale),
-                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), -scale)));
+
+      switch (scale)
+      {
+      case -1:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 1),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 1)));
+        break;
+      case -2:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 2),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 2)));
+        break;
+      case -3:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 3),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 3)));
+        break;
+      case -4:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 4),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 4)));
+        break;
+      case -5:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 5),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 5)));
+        break;
+      case -6:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 6),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 6)));
+        break;
+      case -7:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 7),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 7)));
+        break;
+      case -8:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, high_mean), 8),
+                   vshrq_n_u8(vqsubq_u8(low_mean, in_u8), 8)));
+        break;
+      
+      }
+    }
     }
     // scale =0
     return vreinterpretq_s8_u8(
@@ -565,10 +607,51 @@ void transform_mean_scale(int w, int h, const uint8_t* src, int8_t* dst,
       return int8x16_t();
       // temp = vshlq_n_u8(vabdq_u8(in_u8, mean), scale);
     } else if (scale < 0) {
-      // scale < 0
-      return vreinterpretq_s8_u8(
-          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), -scale),
-                   vshrq_n_u8(vqsubq_u8(mean, in_u8), -scale)));
+
+      switch (scale)
+      {
+      case -1:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 1),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 1)));
+        break;
+      case -2:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 2),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 2)));
+        break;
+      case -3:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 3),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 3)));
+        break;
+      case -4:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 4),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 4)));
+        break;
+      case -5:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 5),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 5)));
+        break;
+      case -6:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 6),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 6)));
+        break;
+      case -7:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 7),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 7)));
+        break;
+      case -8:
+        return vreinterpretq_s8_u8(
+          vsubq_u8(vshrq_n_u8(vqsubq_u8(in_u8, mean), 8),
+                   vshrq_n_u8(vqsubq_u8(mean, in_u8), 8)));
+        break;
+      
+      }
     }
     // scale =0
     return vreinterpretq_s8_u8(

--- a/src/Vitis-AI-Library/math/test/prototype_8bit_to_4bit.cpp
+++ b/src/Vitis-AI-Library/math/test/prototype_8bit_to_4bit.cpp
@@ -67,8 +67,9 @@ int8x8_t normalize(const int16x8_t data2, float mean_f, int fix_pos) {
   /* shift to right, rounded. convert float point to fix point.
    * still represented as i16, but actually range should be [-128, 127];
    * */
-  const int16x8_t data4 =
-      fix_pos > 0 ? vrshrq_n_s16(data3, 1) : vshlq_n_s16(data3, fix_pos);
+  // const int16x8_t data4 =
+  //     fix_pos > 0 ? vrshrq_n_s16(data3, 1) : vshlq_n_s16(data3, fix_pos);
+  const int16x8_t data4 = vrshrq_n_s16(data3, 1)
   LOG_IF(INFO, ENV_PARAM(DEBUG_TEST))
       << "data4 = shift(data3, fixpos) " << to_string(data4) << std::endl;
   /* make sure it is between [-128, 127], saturate truncate


### PR DESCRIPTION
When I want to build the petalinux with Vitis AI library 2.5 for Zynq-7000 devices, I've got the following error:
`/home/emre/petalinux/zynq_miniITX_custom_plnx/build/tmp/work/cortexa9t2hf-neon-xilinx-linux-gnueabi/vitis-ai-library/2.5-r0/git/src/Vitis-AI-Library/math/src/image_util.cpp:569:33`
It is related to variant shifting. Shifting amount must be constant. I've changed related parts of the code so that the shifting amounts are constant.
Another error is the following:
`In function 'int16x8_t vshlq_n_s16(int16x8_t, int)',
inlined from 'int8x8_t normalize(int16x8_t, float, int)' at /home/emre/petalinux/zynq_miniITX_custom_plnx/build/tmp/work/cortexa9t2hf-neon-xilinx-linux-gnueabi/vitis-ai-library/2.5-r0/git/src/Vitis-AI-Library/math/test/prototype_8bit_to_4bit.cpp:71:57:
/home/emre/petalinux/zynq_miniITX_custom_plnx/build/tmp/work/cortexa9t2hf-neon-xilinx-linux-gnueabi/vitis-ai-library/2.5-r0/recipe-sysroot-native/usr/lib/arm-xilinx-linux-gnueabi/gcc/arm-xilinx-linux-gnueabi/11.2.0/include/arm_neon.h:4816:10: error: argument 2 must be a constant immediate
4816 |   return (int16x8_t)__builtin_neon_vshl_nv8hi (__a, __b);`
I've changed the related part as the following :
`const int16x8_t data4 = vrshrq_n_s16(data3, 1)`
with those modifications, petalinux can be built with Vitis AI library 2.5. The details can be found in https://www.notion.so/Fixing-the-errors-for-vitis-ai-library-petalinux-compilation-1df11827caf54aa18ddf6d716b14bf63
