### PR TITLE
update GPU-docker build for pytorch and opt-pytorch

### DIFF
--- a/docker/common/install_opt_pytorch.sh
+++ b/docker/common/install_opt_pytorch.sh
@@ -40,7 +40,7 @@ else
     && python3 -m pip install --upgrade pip wheel setuptools requests \
     && conda config --env --remove-key channels || true \
     && conda config --env --append channels ${VAI_CONDA_CHANNEL} \
-    && conda config --remove channels defaults || true \
+    && conda config --env --remove channels defaults || true \
     && ${command_opt} \
     && conda clean -y --force-pkgs-dirs \
     && rm -fr ~/.cache \

--- a/docker/common/install_torch.sh
+++ b/docker/common/install_torch.sh
@@ -17,7 +17,8 @@ sudo ln -s /opt/conda $VAI_ROOT/conda;
     && sudo mkdir -p $VAI_ROOT/conda/pkgs  && sudo chmod 777  $VAI_ROOT/conda/pkgs \
     && python3 -m pip install --upgrade pip wheel setuptools \
     && sudo  conda config --env --remove-key channels || true  \
-    && sudo conda config --env --append channels ${VAI_CONDA_CHANNEL} 
+    && sudo conda config --env --append channels ${VAI_CONDA_CHANNEL} \
+    && sudo conda config --env --remove channels defaults || true 
 #&& mamba update --force-reinstall --no-deps -n base pytorch_nndct_rocm -c conda-forge \
 torchvision_cmd=" pip install torchvision==0.13.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu "
 if  [[ ${DOCKER_TYPE} == 'gpu' ]]; then
@@ -44,7 +45,8 @@ else
     && mkdir -p $VAI_ROOT/conda/pkgs \
     && python3 -m pip install --upgrade pip wheel setuptools \
     && conda config --env --remove-key channels || true  \
-    && conda config --env --append channels ${VAI_CONDA_CHANNEL} 
+    && conda config --env --append channels ${VAI_CONDA_CHANNEL} \
+    && conda config --env --remove channels defaults || true  
 
     mamba env create -v -f /scratch/${DOCKER_TYPE}_conda/vitis-ai-pytorch.yml \
         && conda activate vitis-ai-pytorch \

--- a/docker/conda/gpu_conda/vitis-ai-optimizer_pytorch.yml
+++ b/docker/conda/gpu_conda/vitis-ai-optimizer_pytorch.yml
@@ -2,7 +2,7 @@ name: vitis-ai-optimizer_pytorch
 
 channels:
   - pytorch
-  - anaconda
+  - prometeia
 
 dependencies:
   - vai_optimizer_pytorch_gpu

--- a/docker/conda/gpu_conda/vitis-ai-pytorch.yml
+++ b/docker/conda/gpu_conda/vitis-ai-pytorch.yml
@@ -3,7 +3,7 @@ name: vitis-ai-pytorch
 channels:
   - pytorch
   - conda-forge
-  - anaconda
+  - prometeia
 
 dependencies:
   - python=3.7


### PR DESCRIPTION
Issue try to resole :
After docker build, Conda env cannot access internet thru default channel due to Anaconda ToS requirement for commercial use case 

I have made changes to below docker build files to achieve an Enterprise ToS-compliant build, for commercial use case. 
Summary of changes : 
1. default channel is removed to be ToS-compliant 
2. swap anaconda with prometeia channel

If the prometeia is not the idea channel to support future build, it may be necessary to provide missing libraries somewhere else.

