### PR TITLE
3.5 docker build mod

### DIFF
--- a/docker/common/install_opt_pytorch.sh
+++ b/docker/common/install_opt_pytorch.sh
@@ -38,7 +38,7 @@ else
     && python3 -m pip install --upgrade pip wheel setuptools requests \
     && conda config --env --remove-key channels || true \
     && conda config --env --append channels ${VAI_CONDA_CHANNEL} \
-    && conda config --remove channels defaults || true \
+    && conda config --env --remove channels defaults || true \
     && ${command_opt} \
     && conda clean -y --force-pkgs-dirs \
     && rm -fr ~/.cache \

--- a/docker/common/install_torch.sh
+++ b/docker/common/install_torch.sh
@@ -17,7 +17,8 @@ sudo ln -s /opt/conda $VAI_ROOT/conda;
     && sudo mkdir -p $VAI_ROOT/conda/pkgs && sudo chmod 777 $VAI_ROOT/conda/pkgs \
     && python3 -m pip install --upgrade pip wheel setuptools \
     && sudo  conda config --env --remove-key channels || true  \
-    && sudo conda config --env --append channels ${VAI_CONDA_CHANNEL} 
+    && sudo conda config --env --append channels ${VAI_CONDA_CHANNEL} \
+    && sudo conda config --env --remove channels defaults || true 
 #&& mamba update --force-reinstall --no-deps -n base pytorch_nndct_rocm -c conda-forge \
 torchvision_cmd=" pip install torchvision==0.14.1 "
 if  [[ ${DOCKER_TYPE} == 'gpu' ]]; then
@@ -47,7 +48,8 @@ else
     && mkdir -p $VAI_ROOT/conda/pkgs \
     && python3 -m pip install --upgrade pip wheel setuptools \
     && conda config --env --remove-key channels || true  \
-    && conda config --env --append channels ${VAI_CONDA_CHANNEL} 
+    && conda config --env --append channels ${VAI_CONDA_CHANNEL} \
+    && conda config --env --remove channels defaults || true  
 
     mamba env create -v -f /scratch/${DOCKER_TYPE}_conda/vitis-ai-pytorch.yml \
         && conda activate vitis-ai-pytorch \

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -78,6 +78,8 @@ docker_run_params=$(cat <<-END
     -v /opt/xilinx/overlaybins:/opt/xilinx/overlaybins \
     -e USER=$user -e UID=$uid -e GID=$gid \
     -v $DOCKER_RUN_DIR:/vitis_ai_home \
+    -v /data:/data \
+    --name VAI_3_5 \
     -v $HERE:/workspace \
     -w /workspace \
     --rm \

--- a/docker_run.sh
+++ b/docker_run.sh
@@ -78,8 +78,6 @@ docker_run_params=$(cat <<-END
     -v /opt/xilinx/overlaybins:/opt/xilinx/overlaybins \
     -e USER=$user -e UID=$uid -e GID=$gid \
     -v $DOCKER_RUN_DIR:/vitis_ai_home \
-    -v /data:/data \
-    --name VAI_3_5 \
     -v $HERE:/workspace \
     -w /workspace \
     --rm \


### PR DESCRIPTION
In the latest docker config for pytorch, after `sudo  conda config --env --remove-key channels || true` "anaconda.com" will be automatically added back to conda channels, fix will be remove default channel using `conda config --env --remove channels defaults || true `
