### PR TITLE
Bug fix: pytorch finetuning

### DIFF
--- a/src/vai_optimizer/pytorch_binding/pytorch_nndct/qproc/adaquant.py
+++ b/src/vai_optimizer/pytorch_binding/pytorch_nndct/qproc/adaquant.py
@@ -882,7 +882,7 @@ please remove it if there is "torch.no_grad()" in forward process')
     total_loss = AverageMeter("layer_loss")
     best_params = self.get_layer_params(layer)
     # torch version >= 1.6
-    if compare_torch_version('1.6.0',CmpFlag.GREATER_EQUAL):
+    if compare_torch_version(CmpFlag.GREATER_EQUAL, '1.6.0'):
       act_func_map = {
         NNDCT_OP.RELU: F.relu,
         NNDCT_OP.RELU6: F.relu6,

--- a/src/vai_quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/qproc/adaquant.py
+++ b/src/vai_quantizer/vai_q_pytorch/pytorch_binding/pytorch_nndct/qproc/adaquant.py
@@ -882,7 +882,7 @@ please remove it if there is "torch.no_grad()" in forward process')
     total_loss = AverageMeter("layer_loss")
     best_params = self.get_layer_params(layer)
     # torch version >= 1.6
-    if compare_torch_version('1.6.0',CmpFlag.GREATER_EQUAL):
+    if compare_torch_version(CmpFlag.GREATER_EQUAL, '1.6.0'):
       act_func_map = {
         NNDCT_OP.RELU: F.relu,
         NNDCT_OP.RELU6: F.relu6,


### PR DESCRIPTION
Wrong order of arguments in function call causes error when model has a function like hardswish