### PR TITLE
Can't build docker image for TF2 and GPU/CPU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: 'Checkout'
+      uses: actions/checkout@v3
+
+    - name: 'Build docker images'
+      run: |
+        cd ./docker/
+        ./docker_build.sh -t cpu -f tf2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
     - name: 'Build docker images'
       run: |
         cd ./docker/
-        ./docker_build.sh -t cpu -f tf2
+        ./docker_build.sh -t gpu -f tf2

--- a/docker/docker_build.sh
+++ b/docker/docker_build.sh
@@ -271,7 +271,7 @@ function main
           REPLY=''
        }
 
-    confirm
+    #confirm
 
     execute
     rtn=$?


### PR DESCRIPTION
This is just a demo for the https://github.com/Xilinx/Vitis-AI/issues/1403 issue. I want to show in the .github/workflows/ci.yml that using the latest version of the repository the list of the following commands  fails:

```
cd ./docker/
./docker_build.sh -t cpu -f tf2
```
I attach a picture of the failure:

![Selección_060](https://github.com/Xilinx/Vitis-AI/assets/104993463/fec2cf1b-374f-4ae7-85ca-a2e87987e1c8)